### PR TITLE
Added note about rebuilding solution

### DIFF
--- a/developer/plugins/how-to-write-plugin_4.20.md
+++ b/developer/plugins/how-to-write-plugin_4.20.md
@@ -83,6 +83,9 @@ Plugins are used to extend the functionality of nopCommerce. nopCommerce has sev
 > [!IMPORTANT]
 > Important note: After each project build, clean the solution before making changes. Some resources will be cached and can lead to developer insanity.
 
+> [!IMPORTANT]
+> You may need to rebuild your solution after adding your plugin. If you do not see DLLs for your plugin under Nop.Web\Plugins\PLUGIN_OUTPUT_DIRECTORY, you need to rebuild your solution. nopCommerce will not list your plugin in the Local Plugins page if your DLLs do not exist in the correct folder in Nop.Web.
+
 ## Handling requests. Controllers, models and views
 
 Now you can see the plugin by going to **Admin area → Configuration → Local Plugins**. But as you guessed our plugin does nothing. It does not even have a user interface for its configuration. Let's create a page to configure the plugin.


### PR DESCRIPTION
Added an important note about rebuilding the solution if your plugin DLLs do not exist. Also added a brief description of where the DLLs need to exist to be listed on the Local Plugins page.