### PR TITLE
fix typo nopCommerce420p.service

### DIFF
--- a/en/user-guide/installing/linux.md
+++ b/en/user-guide/installing/linux.md
@@ -187,11 +187,11 @@ WantedBy=multi-user.target
 
 Start the service
 
-`sudo systemctl start nopCommerce420p.service`
+`sudo systemctl start nopCommerce420.service`
 
 Check the nopCommerce service status
 
-`sudo systemctl status nopCommerce420p.service`
+`sudo systemctl status nopCommerce420.service`
 
 ![nopCommerce installation](_static/linux/status_nopCommerce.jpg)
 


### PR DESCRIPTION
from 
Start the service

`sudo systemctl start nopCommerce420p.service`

Check the nopCommerce service status

`sudo systemctl status nopCommerce420p.service`

to 

Start the service

`sudo systemctl start nopCommerce420.service`

Check the nopCommerce service status

`sudo systemctl status nopCommerce420.service`