### PR TITLE
Example plugin .csproj file in documentation is flawed.

### DIFF
--- a/en/developer/plugins/how-to-write-plugin-4.20.md
+++ b/en/developer/plugins/how-to-write-plugin-4.20.md
@@ -41,7 +41,7 @@ Plugins are used to extend the functionality of nopCommerce. nopCommerce has sev
         <!-- This target execute after "Build" target -->
         <Target Name="NopTarget" AfterTargets="Build">
             <!-- Delete unnecessary libraries from plugins path -->
-            <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(MSBuildProjectDirectory)\ $(OutDir)" Targets="NopClear" />
+            <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" Properties="PluginPath=$(MSBuildProjectDirectory)\$(OutDir)" Targets="NopClear" />
         </Target>
     </Project>
     ```

--- a/en/developer/tutorials/guide-to-expanding-the-functionality-of-the-basic-functions-of-nop-commerce-through-a-plugin.md
+++ b/en/developer/tutorials/guide-to-expanding-the-functionality-of-the-basic-functions-of-nop-commerce-through-a-plugin.md
@@ -61,7 +61,7 @@ After you crate your project successfully open its .csproj file, for that right 
     <!-- This target execute after "Build" target -->
     <Target Name="NopTarget" AfterTargets="Build">
         <!-- Delete unnecessary libraries from plugins path -->
-        <MSBuild Projects="@(ClearPluginAssemblies)" Properties="PluginPath=$(MSBuildProjectDirectory)\ $(OutDir)" Targets="NopClear" />
+        <MSBuild Projects="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" Properties="PluginPath=$(MSBuildProjectDirectory)\$(OutDir)" Targets="NopClear" />
     </Target>
 </Project>
 ```


### PR DESCRIPTION
Example plugin .csproj file in documentation is flawed.

1. ClearPluginAssemblies is not defined.
2. There is an extra space defining PluginPath property.