### PR TITLE
Update new-line options formatting rule examples

### DIFF
--- a/en/developer/tutorials/coding-standards.md
+++ b/en/developer/tutorials/coding-standards.md
@@ -679,10 +679,12 @@ These formatting rules concern the use of new lines to format code.
 
   ```csharp
   //Right
-  if (...) {
+  if (...) 
+  {
       ...
   }
-  else {
+  else 
+  {
       ...
   }
   ```
@@ -700,10 +702,12 @@ These formatting rules concern the use of new lines to format code.
 
   ```csharp
   //Right
-  try {
+  try 
+  {
       ...
   }
-  catch (Exception e) {
+  catch (Exception e) 
+  {
       ...
   }
   ```
@@ -721,13 +725,16 @@ These formatting rules concern the use of new lines to format code.
 
   ```csharp
   //Right
-  try {
+  try 
+  {
       ...
   }
-  catch (Exception e) {
+  catch (Exception e) 
+  {
       ...
   }
-  finally {
+  finally 
+  {
       ...
   }
   ```


### PR DESCRIPTION
The three examples right after `- Require braces to be on a new line for all expressions ("Allman" style).` don't follow the preceding guidelines.