### PR TITLE
Switch-case examples are not properly formatted

### DIFF
--- a/en/developer/tutorials/coding-standards.md
+++ b/en/developer/tutorials/coding-standards.md
@@ -804,7 +804,8 @@ These formatting rules concern the use of indentation to format code.
 
   ```csharp
   //Right
-  switch(c) {
+  switch(c) 
+  {
       case Color.Red:
           Console.WriteLine("The color is red");
           break;
@@ -836,7 +837,8 @@ These formatting rules concern the use of indentation to format code.
 
   ```csharp
   //Right
-  switch(c) {
+  switch(c) 
+  {
       case Color.Red:
           Console.WriteLine("The color is red");
           break;
@@ -871,8 +873,9 @@ These formatting rules concern the use of indentation to format code.
   class C
   {
       private string MyMethod(...)
-      {
-          if (...) {
+      {          
+          if (...) 
+          {
               goto error;
           }
           error:


### PR DESCRIPTION
Switch-case examples are not properly formatted. Not following new-line guidelines