### PR TITLE
Added example for including the logo, plugin.json, and views to the p…

### DIFF
--- a/en/developer/plugins/how-to-write-plugin-4.30.md
+++ b/en/developer/plugins/how-to-write-plugin-4.30.md
@@ -36,6 +36,24 @@ Plugins are used to extend the functionality of nopCommerce. nopCommerce has sev
             <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         </PropertyGroup>
         <ItemGroup>
+		    <None Remove="YOUR_LOGO_PNG" />
+		    <None Remove="plugin.json" />
+            <!--One for each view that should be included in the compiled plugin-->
+		    <None Remove="YOUR_VIEWS" />
+	    </ItemGroup>
+	    <ItemGroup>
+		    <Content Include="YOUR_LOGO_PNG">
+			    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		    </Content>
+		    <Content Include="plugin.json">
+			    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		    </Content>
+             <!--One for each view that should be included in the compiled plugin-->
+		    <Content Include="YOUR_VIEWS">
+			    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		    </Content>
+	    </ItemGroup>
+        <ItemGroup>
             <ProjectReference Include="..\..\Presentation\Nop.Web.Framework\Nop.Web.Framework.csproj" />
             <ClearPluginAssemblies Include="$(MSBuildProjectDirectory)\..\..\Build\ClearPluginAssemblies.proj" />
         </ItemGroup>


### PR DESCRIPTION
…roject file.   At minimum, the plugins.json must be included in the csproject file or it will not appear in the admin configuration local plugin list.

Also, I had to build each local plugin individually before it would show up in the list as well, I wasn't sure if this was an environment issue or not so I didn't update the docs, but it might be worth noting in case someone is struggling to get their plugin to appear.