### PR TITLE
Update installing-local.md

### DIFF
--- a/en/installation-and-upgrading/installing-nopcommerce/installing-local.md
+++ b/en/installation-and-upgrading/installing-nopcommerce/installing-local.md
@@ -54,6 +54,7 @@ nopCommerce requires write permissions for the directories and files described b
   - `\wwwroot\bundles\`
   - `\wwwroot\db_backups\`
   - `\wwwroot\files\exportimport\`
+  - `\wwwroot\css`
   - `\wwwroot\images\`
   - `\wwwroot\images\thumbs\`
   - `\wwwroot\images\uploaded`


### PR DESCRIPTION
After initial installation, the site needs to create wwwroot\css\Slick and create access css files on this folder (seem to be 0 byte overrides, maybe store specific)