### PR TITLE
Missing a semicolon

### DIFF
--- a/en/developer/tutorials/coding-standards.md
+++ b/en/developer/tutorials/coding-standards.md
@@ -1152,7 +1152,7 @@ These formatting rules concern the use of space characters to format code.
 
   ```csharp
   //Wrong
-  int[] x = new int[] { 1,2,3,4,5 }
+  int[] x = new int[] { 1,2,3,4,5 };
   ```
 
 - Remove space before a comma


### PR DESCRIPTION
This coding style example want to explain "Insert space after a comma".
But it's missing a semicolon.

before
```csharp
//Wrong
int[] x = new int[] { 1,2,3,4,5 }
```

after
```csharp
//Wrong
int[] x = new int[] { 1,2,3,4,5 };
```